### PR TITLE
Add the ability to use HTTP Basic auth for connections

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,16 @@ func initApp() *cli.App {
 			Name:  "disable-cert-check",
 			Usage: "disable certificate checking on this endpoint, useful for testing",
 		},
+		cli.StringFlag{
+			Name:  "username",
+			Usage: "rTorrent basic auth username",
+			Value: "",
+		},
+		cli.StringFlag{
+			Name:  "password",
+			Usage: "rTorrent basic auth password",
+			Value: "",
+		},
 	}
 
 	app.Before = setupConnection
@@ -92,6 +102,13 @@ func main() {
 
 func setupConnection(c *cli.Context) error {
 	rTorrentConn := rtorrent.New(c.GlobalString("endpoint"), c.GlobalBool("disable-cert-check"))
+	username := c.GlobalString("username")
+	password := c.GlobalString("password")
+
+	if username != "" || password != "" {
+		rTorrentConn.SetAuth(username, password)
+	}
+
 	conn = rTorrentConn
 	return nil
 }

--- a/rtorrent/rtorrent.go
+++ b/rtorrent/rtorrent.go
@@ -62,6 +62,11 @@ func New(addr string, insecure bool) *RTorrent {
 	}
 }
 
+// SetAuth sets the authentication for communicating with rTorrent
+func (r *RTorrent) SetAuth(username string, password string) {
+	r.xmlrpcClient.SetBasicAuth(username, password)
+}
+
 // Add adds a new torrent by URL
 func (r *RTorrent) Add(url string) error {
 	_, err := r.xmlrpcClient.Call("load_start", url)


### PR DESCRIPTION
I have a seedbox that uses basic auth for its rTorrent XMLRPC and it would be helpful to use it with this library.
