### PR TITLE
Additional commands on add

### DIFF
--- a/rtorrent/rtorrent.go
+++ b/rtorrent/rtorrent.go
@@ -70,7 +70,7 @@ const (
 	// DLabel represents the label of a "Downloading Item"
 	DLabel Field = "d.custom1"
 	// DSizeInBytes represents the size in bytes of a "Downloading Item"
-	DSizeInBytes Field = "d.syze_bytes"
+	DSizeInBytes Field = "d.size_bytes"
 	// DHash represents the hash of a "Downloading Item"
 	DHash Field = "d.hash"
 	// DBasePath represents the base path of a "Downloading Item"

--- a/rtorrent/rtorrent.go
+++ b/rtorrent/rtorrent.go
@@ -65,10 +65,10 @@ const (
 	// ViewSeeding represents the "seeding" view, containing only torrents that are currently seeding
 	ViewSeeding View = "seeding"
 
-	// DNameField represents the name of a "Downloading Items"
-	DNameField Field = "d.name"
-	// DLabelField represents the label of a "Downloading Item"
-	DLabelField Field = "d.custom1"
+	// DName represents the name of a "Downloading Items"
+	DName Field = "d.name"
+	// DLabel represents the label of a "Downloading Item"
+	DLabel Field = "d.custom1"
 	// DSizeInBytes represents the size in bytes of a "Downloading Item"
 	DSizeInBytes Field = "d.syze_bytes"
 	// DHash represents the hash of a "Downloading Item"
@@ -144,11 +144,15 @@ func (r *RTorrent) WithHTTPClient(client *http.Client) *RTorrent {
 //
 // extraArgs can be any valid rTorrent rpc command. For instance:
 //
-// Adds the Torrent by URL (stopepd) and sets the label on the torrent
-//  AddStopped("some-url", &SetArg{"d.custom1", "my-label"})
+// Adds the Torrent by URL (stopped) and sets the label on the torrent
+//  AddStopped("some-url", &FieldValue{"d.custom1", "my-label"})
+// Or:
+//  AddStopped("some-url", DLabel.SetValue("my-label"))
 //
 // Adds the Torrent by URL (stopped) and  sets the label and base path
-//  AddStopped("some-url", &SetArg{"d.custom1", "my-label"}, &SetArg{"d.base_path", "/some/valid/path"})
+//  AddStopped("some-url", &FieldValue{"d.custom1", "my-label"}, &FiedValue{"d.base_path", "/some/valid/path"})
+// Or:
+//  AddStopped("some-url", DLabel.SetValue("my-label"), DBasePath.SetValue("/some/valid/path"))
 func (r *RTorrent) AddStopped(url string, extraArgs ...*FieldValue) error {
 	return r.add("load.normal", []byte(url), extraArgs...)
 }
@@ -159,9 +163,13 @@ func (r *RTorrent) AddStopped(url string, extraArgs ...*FieldValue) error {
 //
 // Adds the Torrent by URL and sets the label on the torrent
 //  Add("some-url", "d.custom1.set=\"my-label\"")
+// Or:
+//  Add("some-url", DLabel.SetValue("my-label"))
 //
 // Adds the Torrent by URL and  sets the label as well as base path
 //  Add("some-url", "d.custom1.set=\"my-label\"", "d.base_path=\"/some/valid/path\"")
+// Or:
+//  Add("some-url", DLabel.SetValue("my-label"), DBasePath.SetValue("/some/valid/path"))
 func (r *RTorrent) Add(url string, extraArgs ...*FieldValue) error {
 	return r.add("load.start", []byte(url), extraArgs...)
 }
@@ -171,10 +179,14 @@ func (r *RTorrent) Add(url string, extraArgs ...*FieldValue) error {
 // extraArgs can be any valid rTorrent rpc command. For instance:
 //
 // Adds the Torrent file (stopped) and sets the label on the torrent
-//  Add(fileData, "d.custom1.set=\"my-label\"")
+//  AddTorrentStopped(fileData, "d.custom1.set=\"my-label\"")
+// Or:
+//  AddTorrentStopped(fileData, DLabel.SetValue("my-label"))
 //
 // Adds the Torrent file and (stopped) sets the label and base path
-//  Add(fileData, "d.custom1.set=\"my-label\"", "d.base_path=\"/some/valid/path\"")
+//  AddTorrentStopped(fileData, "d.custom1.set=\"my-label\"", "d.base_path=\"/some/valid/path\"")
+// Or:
+//  AddTorrentStopped(fileData, DLabel.SetValue("my-label"), DBasePath.SetValue("/some/valid/path"))
 func (r *RTorrent) AddTorrentStopped(data []byte, extraArgs ...*FieldValue) error {
 	return r.add("load.raw", data, extraArgs...)
 }
@@ -185,9 +197,13 @@ func (r *RTorrent) AddTorrentStopped(data []byte, extraArgs ...*FieldValue) erro
 //
 // Adds the Torrent file and sets the label on the torrent
 //  Add(fileData, "d.custom1.set=\"my-label\"")
+// Or:
+//  AddTorrent(fileData, DLabel.SetValue("my-label"))
 //
 // Adds the Torrent file and  sets the label and base path
 //  Add(fileData, "d.custom1.set=\"my-label\"", "d.base_path=\"/some/valid/path\"")
+// Or:
+//  AddTorrent(fileData, DLabel.SetValue("my-label"), DBasePath.SetValue("/some/valid/path"))
 func (r *RTorrent) AddTorrent(data []byte, extraArgs ...*FieldValue) error {
 	return r.add("load.raw_start", data, extraArgs...)
 }
@@ -297,7 +313,7 @@ func (r *RTorrent) UpRate() (int, error) {
 
 // GetTorrents returns all of the torrents reported by this RTorrent instance
 func (r *RTorrent) GetTorrents(view View) ([]Torrent, error) {
-	args := []interface{}{"", string(view), DNameField.Query(), DSizeInBytes.Query(), DHash.Query(), DLabelField.Query(), DBasePath.Query(), DIsActive.Query(), DComplete.Query(), DRatio.Query()}
+	args := []interface{}{"", string(view), DName.Query(), DSizeInBytes.Query(), DHash.Query(), DLabel.Query(), DBasePath.Query(), DIsActive.Query(), DComplete.Query(), DRatio.Query()}
 	results, err := r.xmlrpcClient.Call("d.multicall2", args...)
 	var torrents []Torrent
 	if err != nil {

--- a/rtorrent/rtorrent.go
+++ b/rtorrent/rtorrent.go
@@ -83,37 +83,61 @@ func (r *RTorrent) WithHTTPClient(client *http.Client) *RTorrent {
 }
 
 // AddStopped adds a new torrent by URL in a stopped state
-func (r *RTorrent) AddStopped(url string) error {
-	_, err := r.xmlrpcClient.Call("load.normal", "", url)
-	if err != nil {
-		return errors.Wrap(err, "load.normal XMLRPC call failed")
-	}
-	return nil
+//
+// extraArgs can be any valid rTorrent rpc command. For instance:
+//
+// Adds the Torrent by URL (stopepd) and sets the label on the torrent
+//  AddStopped("some-url", "d.custom1.set=\"my-label\"")
+//
+// Adds the Torrent by URL (stopped) and  sets the label and base path
+//  AddStopped("some-url", "d.custom1.set=\"my-label\"", "d.base_path=\"/some/valid/path\"")
+func (r *RTorrent) AddStopped(url string, extraArgs ...interface{}) error {
+	return r.add("load.normal", []interface{}{url, extraArgs})
 }
 
 // Add adds a new torrent by URL and starts the torrent
-func (r *RTorrent) Add(url string) error {
-	_, err := r.xmlrpcClient.Call("load.start", "", url)
-	if err != nil {
-		return errors.Wrap(err, "load.start XMLRPC call failed")
-	}
-	return nil
+//
+// extraArgs can be any valid rTorrent rpc command. For instance:
+//
+// Adds the Torrent by URL and sets the label on the torrent
+//  Add("some-url", "d.custom1.set=\"my-label\"")
+//
+// Adds the Torrent by URL and  sets the label as well as base path
+//  Add("some-url", "d.custom1.set=\"my-label\"", "d.base_path=\"/some/valid/path\"")
+func (r *RTorrent) Add(url string, extraArgs ...interface{}) error {
+	return r.add("load.start", []interface{}{url, extraArgs})
 }
 
 // AddTorrentStopped adds a new torrent by the torrent files data but does not start the torrent
-func (r *RTorrent) AddTorrentStopped(data []byte) error {
-	_, err := r.xmlrpcClient.Call("load.raw", "", data)
-	if err != nil {
-		return errors.Wrap(err, "load.raw XMLRPC call failed")
-	}
-	return nil
+//
+// extraArgs can be any valid rTorrent rpc command. For instance:
+//
+// Adds the Torrent file (stopped) and sets the label on the torrent
+//  Add(fileData, "d.custom1.set=\"my-label\"")
+//
+// Adds the Torrent file and (stopped) sets the label and base path
+//  Add(fileData, "d.custom1.set=\"my-label\"", "d.base_path=\"/some/valid/path\"")
+func (r *RTorrent) AddTorrentStopped(data []byte, extraArgs ...interface{}) error {
+	return r.add("load.raw", []interface{}{data, extraArgs})
 }
 
 // AddTorrent adds a new torrent by the torrent files data and starts the torrent
-func (r *RTorrent) AddTorrent(data []byte) error {
-	_, err := r.xmlrpcClient.Call("load.raw_start", "", data)
+//
+// extraArgs can be any valid rTorrent rpc command. For instance:
+//
+// Adds the Torrent file and sets the label on the torrent
+//  Add(fileData, "d.custom1.set=\"my-label\"")
+//
+// Adds the Torrent file and  sets the label and base path
+//  Add(fileData, "d.custom1.set=\"my-label\"", "d.base_path=\"/some/valid/path\"")
+func (r *RTorrent) AddTorrent(data []byte, extraArgs ...interface{}) error {
+	return r.add("load.raw_start", []interface{}{data, extraArgs})
+}
+
+func (r *RTorrent) add(cmd string, args ...interface{}) error {
+	_, err := r.xmlrpcClient.Call(cmd, "", args)
 	if err != nil {
-		return errors.Wrap(err, "load.raw_start XMLRPC call failed")
+		return errors.Wrap(err, fmt.Sprintf("%s XMLRPC call failed", cmd))
 	}
 	return nil
 }

--- a/rtorrent/rtorrent_test.go
+++ b/rtorrent/rtorrent_test.go
@@ -191,7 +191,8 @@ func TestRTorrent(t *testing.T) {
 		})
 
 		t.Run("by url (stopped)", func(t *testing.T) {
-			err := client.AddStopped("http://releases.ubuntu.com/19.04/ubuntu-19.04-live-server-amd64.iso.torrent")
+			label := DLabel.SetValue("test-label")
+			err := client.AddStopped("http://releases.ubuntu.com/19.04/ubuntu-19.04-live-server-amd64.iso.torrent", label)
 			require.NoError(t, err)
 
 			t.Run("get torrent", func(t *testing.T) {
@@ -215,7 +216,7 @@ func TestRTorrent(t *testing.T) {
 				require.Len(t, torrents, 1)
 				require.Equal(t, "B7B0FBAB74A85D4AC170662C645982A862826455", torrents[0].Hash)
 				require.Equal(t, "ubuntu-19.04-live-server-amd64.iso", torrents[0].Name)
-				require.Equal(t, "", torrents[0].Label)
+				require.Equal(t, label.Value, torrents[0].Label)
 				require.Equal(t, 784334848, torrents[0].Size)
 				//no path yet since the torrent is stopped
 				require.Equal(t, "", torrents[0].Path)
@@ -345,7 +346,8 @@ func TestRTorrent(t *testing.T) {
 			require.NoError(t, err)
 			require.NotEmpty(t, b)
 
-			err = client.AddTorrentStopped(b)
+			label := DLabel.SetValue("test-label")
+			err = client.AddTorrentStopped(b, label)
 			require.NoError(t, err)
 
 			t.Run("get torrent", func(t *testing.T) {
@@ -358,7 +360,7 @@ func TestRTorrent(t *testing.T) {
 				require.Len(t, torrents, 1)
 				require.Equal(t, "36C67464C37A83478CEFF54932B5A9BDDEA636F3", torrents[0].Hash)
 				require.Equal(t, "ubuntu-20.04.1-live-server-amd64.iso", torrents[0].Name)
-				require.Equal(t, "", torrents[0].Label)
+				require.Equal(t, label.Value, torrents[0].Label)
 				require.Equal(t, 958398464, torrents[0].Size)
 
 				t.Run("delete torrent", func(t *testing.T) {


### PR DESCRIPTION
Adds the capability to set certain attributes as an item is being added.

For instance to set the label at the same time as adding a torrent:
```
rtorrentClient.Add("some-torrent-url", DLabel.SetValue("my-label");
```
Added the types Field and Field Value.
- Field represents the current supported (and used) attributes by this library on "Download Items" (d.* commands) and "File Items" (f.* commands)
- FieldValue is a convenience type to hold and convert a particular Field that one wants to set on a rTorrent item. 